### PR TITLE
Implements bypass for fresh deployments in PaymasterController

### DIFF
--- a/contracts/PaymasterController.sol
+++ b/contracts/PaymasterController.sol
@@ -63,22 +63,29 @@ contract PaymasterController is IPaymasterController, Permissions {
 
 
     modifier whenConfigured() {
-        if (_isFreshDeployment()) {
-            // Bypass for fresh deploy
-            _;
-            return;
+        bool imaAddress = address(ima) == address(0);
+        bool marionetteAddress = address(marionette) == address(0);
+        bool paymasterAddress = address(paymaster) == address(0);
+        bool chainHash = paymasterChainHash == 0;
 
+        if (
+            imaAddress &&
+            marionetteAddress &&
+            paymasterAddress &&
+            chainHash
+        ) {
+            return;
         }
-        if (address(ima) == address(0)) {
+        if (imaAddress) {
             revert MessageProxyForMainnetAddressIsNotSet();
         }
-        if (address(marionette) == address(0)) {
+        if (marionetteAddress) {
             revert MarionetteAddressIsNotSet();
         }
-        if (address(paymaster) == address(0)) {
+        if (paymasterAddress) {
             revert PaymasterAddressIsNotSet();
         }
-        if (paymasterChainHash == 0) {
+        if (chainHash) {
             revert EuropaChainHashIsNotSet();
         }
         _;
@@ -182,9 +189,6 @@ contract PaymasterController is IPaymasterController, Permissions {
     }
 
     function _callPaymaster(bytes memory data) private whenConfigured {
-        if (_isFreshDeployment()){
-            return;
-        }
         ima.postOutgoingMessage(
             paymasterChainHash,
             address(marionette),
@@ -196,11 +200,4 @@ contract PaymasterController is IPaymasterController, Permissions {
         );
     }
 
-    function _isFreshDeployment() private view returns (bool){
-        return address(ima) == address(0) &&
-            address(marionette) == address(0) &&
-            address(paymaster) == address(0) &&
-            paymasterChainHash == 0;
-
-    }
 }

--- a/contracts/PaymasterController.sol
+++ b/contracts/PaymasterController.sol
@@ -48,6 +48,7 @@ contract PaymasterController is IPaymasterController, Permissions {
     using AddressUpgradeable for address;
     using AddressUpgradeable for address payable;
 
+
     bytes32 public constant PAYMASTER_SETTER_ROLE = keccak256("PAYMASTER_SETTER_ROLE");
 
     IMessageProxyForMainnet public ima;
@@ -60,7 +61,14 @@ contract PaymasterController is IPaymasterController, Permissions {
     error PaymasterAddressIsNotSet();
     error EuropaChainHashIsNotSet();
 
+
     modifier whenConfigured() {
+        if (_isFreshDeployment()) {
+            // Bypass for fresh deploy
+            _;
+            return;
+
+        }
         if (address(ima) == address(0)) {
             revert MessageProxyForMainnetAddressIsNotSet();
         }
@@ -75,6 +83,7 @@ contract PaymasterController is IPaymasterController, Permissions {
         }
         _;
     }
+
 
     modifier onlyPaymasterSetter() {
         if (!hasRole(PAYMASTER_SETTER_ROLE, msg.sender)) {
@@ -115,9 +124,9 @@ contract PaymasterController is IPaymasterController, Permissions {
 
     function addSchain(string calldata name) external override allow("Schains") {
         _callPaymaster(abi.encodeWithSelector(
-            paymaster.addSchain.selector,
-            name
-        ));
+                paymaster.addSchain.selector,
+                name
+            ));
     }
 
     function removeSchain(bytes32 schainHash) external override allow("Schains") {
@@ -173,6 +182,9 @@ contract PaymasterController is IPaymasterController, Permissions {
     }
 
     function _callPaymaster(bytes memory data) private whenConfigured {
+        if (_isFreshDeployment()){
+            return;
+        }
         ima.postOutgoingMessage(
             paymasterChainHash,
             address(marionette),
@@ -182,5 +194,13 @@ contract PaymasterController is IPaymasterController, Permissions {
                 data
             )
         );
+    }
+
+    function _isFreshDeployment() private view returns (bool){
+        return address(ima) == address(0) &&
+            address(marionette) == address(0) &&
+            address(paymaster) == address(0) &&
+            paymasterChainHash == 0;
+
     }
 }

--- a/contracts/PaymasterController.sol
+++ b/contracts/PaymasterController.sol
@@ -62,36 +62,6 @@ contract PaymasterController is IPaymasterController, Permissions {
     error EuropaChainHashIsNotSet();
 
 
-    modifier whenConfigured() {
-        bool imaAddress = address(ima) == address(0);
-        bool marionetteAddress = address(marionette) == address(0);
-        bool paymasterAddress = address(paymaster) == address(0);
-        bool chainHash = paymasterChainHash == 0;
-
-        if (
-            imaAddress &&
-            marionetteAddress &&
-            paymasterAddress &&
-            chainHash
-        ) {
-            return;
-        }
-        if (imaAddress) {
-            revert MessageProxyForMainnetAddressIsNotSet();
-        }
-        if (marionetteAddress) {
-            revert MarionetteAddressIsNotSet();
-        }
-        if (paymasterAddress) {
-            revert PaymasterAddressIsNotSet();
-        }
-        if (chainHash) {
-            revert EuropaChainHashIsNotSet();
-        }
-        _;
-    }
-
-
     modifier onlyPaymasterSetter() {
         if (!hasRole(PAYMASTER_SETTER_ROLE, msg.sender)) {
             revert RoleRequired(PAYMASTER_SETTER_ROLE);
@@ -131,9 +101,9 @@ contract PaymasterController is IPaymasterController, Permissions {
 
     function addSchain(string calldata name) external override allow("Schains") {
         _callPaymaster(abi.encodeWithSelector(
-                paymaster.addSchain.selector,
-                name
-            ));
+            paymaster.addSchain.selector,
+            name
+        ));
     }
 
     function removeSchain(bytes32 schainHash) external override allow("Schains") {
@@ -188,16 +158,62 @@ contract PaymasterController is IPaymasterController, Permissions {
         ));
     }
 
-    function _callPaymaster(bytes memory data) private whenConfigured {
+
+    function _callPaymaster(bytes memory data) private {
+        address imaAddress = address(ima);
+        address marionetteAddress = address(marionette);
+        address paymasterAddress = address(paymaster);
+        bytes32 chainHash = paymasterChainHash;
+
+        if (_isFreshDeployment(imaAddress, marionetteAddress, paymasterAddress, chainHash)) {
+            // Bypass of fresh deployments
+            return;
+        }
+
+        _checkConfigs(imaAddress, marionetteAddress, paymasterAddress, chainHash);
+
         ima.postOutgoingMessage(
-            paymasterChainHash,
-            address(marionette),
+            chainHash,
+            marionetteAddress,
             Encoder.encodeFunctionCall(
-                address(paymaster),
+                paymasterAddress,
                 0,
                 data
             )
         );
     }
 
+    function _checkConfigs (
+        address imaAddress,
+        address marionetteAddress,
+        address paymasterAddress,
+        bytes32 chainHash
+    ) private pure {
+        if (imaAddress == address(0)) {
+            revert MessageProxyForMainnetAddressIsNotSet();
+        }
+        if (marionetteAddress == address(0)) {
+            revert MarionetteAddressIsNotSet();
+        }
+        if (paymasterAddress == address(0)) {
+            revert PaymasterAddressIsNotSet();
+        }
+        if (chainHash == 0) {
+            revert EuropaChainHashIsNotSet();
+        }
+    }
+
+    function _isFreshDeployment (
+        address imaAddress,
+        address marionetteAddress,
+        address paymasterAddress,
+        bytes32 chainHash
+    ) private pure returns (bool) {
+        return (
+            imaAddress == address(0) &&
+            marionetteAddress == address(0) &&
+            paymasterAddress == address(0) &&
+            chainHash == 0
+        );
+    }
 }

--- a/contracts/PaymasterController.sol
+++ b/contracts/PaymasterController.sol
@@ -48,7 +48,6 @@ contract PaymasterController is IPaymasterController, Permissions {
     using AddressUpgradeable for address;
     using AddressUpgradeable for address payable;
 
-
     bytes32 public constant PAYMASTER_SETTER_ROLE = keccak256("PAYMASTER_SETTER_ROLE");
 
     IMessageProxyForMainnet public ima;
@@ -157,7 +156,6 @@ contract PaymasterController is IPaymasterController, Permissions {
             nodesAmount
         ));
     }
-
 
     function _callPaymaster(bytes memory data) private {
         address imaAddress = address(ima);

--- a/migrations/upgrade.ts
+++ b/migrations/upgrade.ts
@@ -33,7 +33,7 @@ class SkaleManagerUpgrader extends Upgrader {
                     contractNamesToUpgrade,
                     instance,
                     name: "skale-manager",
-                    version: targetVersion
+                    oldVersion: targetVersion
                 },
                 submitter
             );

--- a/migrations/upgrade.ts
+++ b/migrations/upgrade.ts
@@ -33,7 +33,7 @@ class SkaleManagerUpgrader extends Upgrader {
                     contractNamesToUpgrade,
                     instance,
                     name: "skale-manager",
-                    oldVersion: targetVersion
+                    version: targetVersion
                 },
                 submitter
             );

--- a/test/PaymasterControler.ts
+++ b/test/PaymasterControler.ts
@@ -1,0 +1,164 @@
+import * as chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import {ConstantsHolder,
+         ContractManager,
+         Nodes,
+         SchainsInternalMock,
+         Schains,
+         SkaleDKGTester,
+         SkaleManager,
+         ValidatorService,} from "../typechain-types";
+import {Wallet} from "ethers";
+import {privateKeys} from "./tools/private-keys";
+import {deployConstantsHolder} from "./tools/deploy/constantsHolder";
+import {deployContractManager} from "./tools/deploy/contractManager";
+import {deployNodes} from "./tools/deploy/nodes";
+import {deploySchainsInternalMock} from "./tools/deploy/test/schainsInternalMock";
+import {deploySchains} from "./tools/deploy/schains";
+import {deploySkaleDKGTester} from "./tools/deploy/test/skaleDKGTester";
+import {deploySkaleManager} from "./tools/deploy/skaleManager";
+import {deployNodeRotation} from "./tools/deploy/nodeRotation";
+import {ethers} from "hardhat";
+import {SignerWithAddress} from "@nomicfoundation/hardhat-ethers/signers";
+import {deployWallets} from "./tools/deploy/wallets";
+import {fastBeforeEach} from "./tools/mocha";
+import {getPublicKey, getValidatorIdSignature} from "./tools/signatures";
+import {schainParametersType, SchainType} from "./tools/types";
+import {deployDelegationController} from "./tools/deploy/delegation/delegationController";
+import {deployPaymasterControllerNoInit, setupPaymasterController} from "./tools/deploy/paymasterController";
+import {deployFunctionFactory} from "./tools/deploy/factory";
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe("Schains", () => {
+    let owner: SignerWithAddress;
+    let validator: SignerWithAddress;
+    let richGuy1: SignerWithAddress;
+    let richGuy2: SignerWithAddress;
+    let richGuy3: SignerWithAddress;
+    let richGuy4: SignerWithAddress;
+    let nodeAddress1: Wallet;
+    let nodeAddress2: Wallet;
+    let nodeAddress3: Wallet;
+    let nodeAddress4: Wallet;
+
+    let constantsHolder: ConstantsHolder;
+    let contractManager: ContractManager;
+    let schains: Schains;
+    let schainsInternal: SchainsInternalMock;
+    let nodes: Nodes;
+    let validatorService: ValidatorService;
+    let skaleDKG: SkaleDKGTester;
+    let skaleManager: SkaleManager;
+
+
+    fastBeforeEach(async () => {
+        [owner, validator, richGuy1, richGuy2, richGuy3, richGuy4] = await ethers.getSigners();
+
+        nodeAddress1 = new Wallet(String(privateKeys[3])).connect(ethers.provider);
+        nodeAddress2 = new Wallet(String(privateKeys[4])).connect(ethers.provider);
+        nodeAddress3 = new Wallet(String(privateKeys[5])).connect(ethers.provider);
+        nodeAddress4 = new Wallet(String(privateKeys[0])).connect(ethers.provider);
+
+        await richGuy1.sendTransaction({to: nodeAddress1.address, value: ethers.parseEther("10000")});
+        await richGuy2.sendTransaction({to: nodeAddress2.address, value: ethers.parseEther("10000")});
+        await richGuy3.sendTransaction({to: nodeAddress3.address, value: ethers.parseEther("10000")});
+        await richGuy4.sendTransaction({to: nodeAddress4.address, value: ethers.parseEther("10000")});
+
+        contractManager = await deployContractManager();
+
+        constantsHolder = await deployConstantsHolder(contractManager);
+        await deployPaymasterControllerNoInit(contractManager);
+        const deployValidatorService = deployFunctionFactory("ValidatorService") as (contractManager: ContractManager) => Promise<ValidatorService>;
+        validatorService = await deployValidatorService(contractManager);
+        nodes = await deployNodes(contractManager);
+        // await contractManager.setContractsAddress("Nodes", nodes.address);
+        schainsInternal = await deploySchainsInternalMock(contractManager);
+        await contractManager.setContractsAddress("SchainsInternal", schainsInternal);
+        schains = await deploySchains(contractManager);
+
+        await deployDelegationController(contractManager);
+        await deployConstantsHolder(contractManager);
+
+
+        skaleDKG = await deploySkaleDKGTester(contractManager);
+        await contractManager.setContractsAddress("SkaleDKG", skaleDKG);
+        skaleManager = await deploySkaleManager(contractManager);
+        await deployNodeRotation(contractManager);
+        await deployWallets(contractManager);
+
+        const VALIDATOR_MANAGER_ROLE = await validatorService.VALIDATOR_MANAGER_ROLE();
+        await validatorService.grantRole(VALIDATOR_MANAGER_ROLE, owner.address);
+        const CONSTANTS_HOLDER_MANAGER_ROLE = await constantsHolder.CONSTANTS_HOLDER_MANAGER_ROLE();
+        await constantsHolder.grantRole(CONSTANTS_HOLDER_MANAGER_ROLE, owner.address);
+        const NODE_MANAGER_ROLE = await nodes.NODE_MANAGER_ROLE();
+        await nodes.grantRole(NODE_MANAGER_ROLE, owner.address);
+
+        await validatorService.connect(validator).registerValidator("D2", "D2 is even", 0, 0);
+        const validatorIndex = await validatorService.getValidatorId(validator.address);
+        await validatorService.enableValidator(validatorIndex);
+        const signature = await getValidatorIdSignature(validatorIndex, nodeAddress1);
+        await validatorService.connect(validator).linkNodeAddress(nodeAddress1.address, signature);
+        const signature2 = await getValidatorIdSignature(validatorIndex, nodeAddress2);
+        await validatorService.connect(validator).linkNodeAddress(nodeAddress2.address, signature2);
+        const signature3 = await getValidatorIdSignature(validatorIndex, nodeAddress3);
+        await validatorService.connect(validator).linkNodeAddress(nodeAddress3.address, signature3);
+        const signature4 = await getValidatorIdSignature(validatorIndex, nodeAddress4);
+        await validatorService.connect(validator).linkNodeAddress(nodeAddress4.address, signature4);
+        await constantsHolder.setMSR(0);
+    });
+
+    describe("should bypass checks for fresh deployments", () => {
+        it("should create Schains with and without parameters initialized", async () => {
+            const nodesCount = 2;
+            for (const index of Array.from(Array(nodesCount).keys())) {
+                const hexIndex = ("0" + index.toString(16)).slice(-2);
+                await skaleManager.connect(nodeAddress1).createNode(
+                    8545, // port
+                    0, // nonce
+                    "0x7f0000" + hexIndex, // ip
+                    "0x7f0000" + hexIndex, // public ip
+                    getPublicKey(nodeAddress1), // public key
+                    "D2-" + hexIndex, // name
+                    "some.domain.name");
+            }
+
+            const deposit = await schains.getSchainPrice(4, 5);
+
+
+            await schains.addSchain(
+                owner.address,
+                deposit,
+                ethers.AbiCoder.defaultAbiCoder().encode(
+                    [schainParametersType],
+                    [{
+                        lifetime: 5,
+                        typeOfSchain: SchainType.TEST,
+                        nonce: 0,
+                        name: "d2",
+                        originator: ethers.ZeroAddress,
+                        options: []
+                    }]
+                )
+            );
+
+            await setupPaymasterController(contractManager);
+            await schains.addSchain(
+                owner.address,
+                deposit,
+                ethers.AbiCoder.defaultAbiCoder().encode(
+                    [schainParametersType],
+                    [{
+                        lifetime: 5,
+                        typeOfSchain: SchainType.TEST,
+                        nonce: 0,
+                        name: "d3",
+                        originator: ethers.ZeroAddress,
+                        options: []
+                    }]
+                )
+            );
+        });
+    });
+});

--- a/test/PaymasterControler.ts
+++ b/test/PaymasterControler.ts
@@ -34,7 +34,7 @@ import {ZeroAddress} from "ethers";
 chai.should();
 chai.use(chaiAsPromised);
 
-describe("Schains", () => {
+describe("Paymaster Controller", () => {
     let owner: SignerWithAddress;
     let validator: SignerWithAddress;
     let richGuy1: SignerWithAddress;

--- a/test/PaymasterControler.ts
+++ b/test/PaymasterControler.ts
@@ -7,7 +7,8 @@ import {ConstantsHolder,
          Schains,
          SkaleDKGTester,
          SkaleManager,
-         ValidatorService,} from "../typechain-types";
+         ValidatorService,
+         PaymasterController,} from "../typechain-types";
 import {Wallet} from "ethers";
 import {privateKeys} from "./tools/private-keys";
 import {deployConstantsHolder} from "./tools/deploy/constantsHolder";
@@ -27,6 +28,8 @@ import {schainParametersType, SchainType} from "./tools/types";
 import {deployDelegationController} from "./tools/deploy/delegation/delegationController";
 import {deployPaymasterControllerNoInit, setupPaymasterController} from "./tools/deploy/paymasterController";
 import {deployFunctionFactory} from "./tools/deploy/factory";
+import {expect} from "chai";
+import {ZeroAddress} from "ethers";
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -51,7 +54,7 @@ describe("Schains", () => {
     let validatorService: ValidatorService;
     let skaleDKG: SkaleDKGTester;
     let skaleManager: SkaleManager;
-
+    let paymasterController: PaymasterController;
 
     fastBeforeEach(async () => {
         [owner, validator, richGuy1, richGuy2, richGuy3, richGuy4] = await ethers.getSigners();
@@ -69,7 +72,7 @@ describe("Schains", () => {
         contractManager = await deployContractManager();
 
         constantsHolder = await deployConstantsHolder(contractManager);
-        await deployPaymasterControllerNoInit(contractManager);
+        paymasterController = await deployPaymasterControllerNoInit(contractManager);
         const deployValidatorService = deployFunctionFactory("ValidatorService") as (contractManager: ContractManager) => Promise<ValidatorService>;
         validatorService = await deployValidatorService(contractManager);
         nodes = await deployNodes(contractManager);
@@ -110,7 +113,7 @@ describe("Schains", () => {
     });
 
     describe("should bypass checks for fresh deployments", () => {
-        it("should create Schains with and without parameters initialized", async () => {
+        it("should create Schains only with all or without any parameters initialized", async () => {
             const nodesCount = 2;
             for (const index of Array.from(Array(nodesCount).keys())) {
                 const hexIndex = ("0" + index.toString(16)).slice(-2);
@@ -142,6 +145,76 @@ describe("Schains", () => {
                     }]
                 )
             );
+            await paymasterController.setMarionetteAddress(await contractManager.getAddress());
+
+            await expect(schains.addSchain(
+                owner.address,
+                deposit,
+                ethers.AbiCoder.defaultAbiCoder().encode(
+                    [schainParametersType],
+                    [{
+                        lifetime: 5,
+                        typeOfSchain: SchainType.TEST,
+                        nonce: 0,
+                        name: "d3",
+                        originator: ethers.ZeroAddress,
+                        options: []
+                    }]
+                )
+            )).to.be.revertedWithCustomError(paymasterController, "MessageProxyForMainnetAddressIsNotSet");
+            await paymasterController.setMarionetteAddress(ZeroAddress);
+            await paymasterController.setImaAddress(await contractManager.getAddress());
+
+            await expect(schains.addSchain(
+                owner.address,
+                deposit,
+                ethers.AbiCoder.defaultAbiCoder().encode(
+                    [schainParametersType],
+                    [{
+                        lifetime: 5,
+                        typeOfSchain: SchainType.TEST,
+                        nonce: 0,
+                        name: "d3",
+                        originator: ethers.ZeroAddress,
+                        options: []
+                    }]
+                )
+            )).to.be.revertedWithCustomError(paymasterController, "MarionetteAddressIsNotSet");
+
+            await paymasterController.setMarionetteAddress(await contractManager.getAddress());
+            await expect(schains.addSchain(
+                owner.address,
+                deposit,
+                ethers.AbiCoder.defaultAbiCoder().encode(
+                    [schainParametersType],
+                    [{
+                        lifetime: 5,
+                        typeOfSchain: SchainType.TEST,
+                        nonce: 0,
+                        name: "d3",
+                        originator: ethers.ZeroAddress,
+                        options: []
+                    }]
+                )
+            )).to.be.revertedWithCustomError(paymasterController, "PaymasterAddressIsNotSet");
+
+            await paymasterController.setPaymasterAddress(await contractManager.getAddress());
+            await expect(schains.addSchain(
+                owner.address,
+                deposit,
+                ethers.AbiCoder.defaultAbiCoder().encode(
+                    [schainParametersType],
+                    [{
+                        lifetime: 5,
+                        typeOfSchain: SchainType.TEST,
+                        nonce: 0,
+                        name: "d3",
+                        originator: ethers.ZeroAddress,
+                        options: []
+                    }]
+                )
+            )).to.be.revertedWithCustomError(paymasterController, "EuropaChainHashIsNotSet");
+
 
             await setupPaymasterController(contractManager);
             await schains.addSchain(

--- a/test/tools/deploy/paymasterController.ts
+++ b/test/tools/deploy/paymasterController.ts
@@ -3,19 +3,28 @@ import {ContractManager, PaymasterController} from "../../../typechain-types";
 import {deployFunctionFactory} from "./factory";
 import {deployImaMock} from "./test/imaMock";
 
+export const setupPaymasterController = async (contractManager: ContractManager) => {
+    const ima = await deployImaMock(contractManager);
+
+    // Initialize
+    const paymasterControllerFactory = await ethers.getContractFactory("PaymasterController");
+    const paymasterController = await paymasterControllerFactory.attach(
+        await contractManager.getContract("PaymasterController")
+    ) as unknown as PaymasterController;
+    await paymasterController.setImaAddress(ima);
+    await paymasterController.setMarionetteAddress(paymasterController);
+    await paymasterController.setPaymasterAddress(paymasterController);
+    await paymasterController.setPaymasterChainHash(ethers.solidityPackedKeccak256(["string"], ["d2"]));
+};
+
 export const deployPaymasterController = deployFunctionFactory<PaymasterController>(
     "PaymasterController",
-    async (contractManager: ContractManager) => {
-        const ima = await deployImaMock(contractManager);
-
-        // Initialize
-        const paymasterControllerFactory = await ethers.getContractFactory("PaymasterController");
-        const paymasterController = await paymasterControllerFactory.attach(
-            await contractManager.getContract("PaymasterController")
-        ) as unknown as PaymasterController;
-        await paymasterController.setImaAddress(ima);
-        await paymasterController.setMarionetteAddress(paymasterController);
-        await paymasterController.setPaymasterAddress(paymasterController);
-        await paymasterController.setPaymasterChainHash(ethers.solidityPackedKeccak256(["string"], ["d2"]));
-    },
+    setupPaymasterController,
 );
+
+export const deployPaymasterControllerNoInit = deployFunctionFactory<PaymasterController>(
+    "PaymasterController"
+);
+
+
+

--- a/test/tools/deploy/paymasterController.ts
+++ b/test/tools/deploy/paymasterController.ts
@@ -25,6 +25,3 @@ export const deployPaymasterController = deployFunctionFactory<PaymasterControll
 export const deployPaymasterControllerNoInit = deployFunctionFactory<PaymasterController>(
     "PaymasterController"
 );
-
-
-


### PR DESCRIPTION
Changes PaymasterController to bypass calls to IMA and verification when all addresses are set to 0x0 (meaning controller was not setup).

Fixes #1163