### PR TITLE
Remove contract registration from main deployment process

### DIFF
--- a/migrations/deploySkaleTokenL2.ts
+++ b/migrations/deploySkaleTokenL2.ts
@@ -75,9 +75,6 @@ async function main() {
     const skaleTokenAddress = await skaleToken.getAddress();
     console.log(`${skaleTokenName} deployed at:`, skaleTokenAddress);
 
-    console.log(`Registering ${skaleTokenName} in ContractManager`);
-    await (await contractManager.setContractsAddress(skaleTokenName, skaleToken)).wait();
-
     console.log(`Granting MINTER_ROLE for L2 bridge: ${l2BridgeAddress}`);
     const MINTER_ROLE = await skaleToken.MINTER_ROLE();
     await (await skaleToken.grantRole(MINTER_ROLE, l2BridgeAddress)).wait();
@@ -87,6 +84,8 @@ async function main() {
 
     console.log("Verify contract");
     await verify(skaleTokenName, skaleTokenAddress, [contractManagerAddress, [], remoteTokenAddress, l2BridgeAddress]);
+
+    chalk.yellow("Warning: Ensure that setContractsAddress in ContractManager is executed via the multisig.");
 
     console.log("Done");
 }

--- a/migrations/deploySkaleTokenL2.ts
+++ b/migrations/deploySkaleTokenL2.ts
@@ -75,6 +75,14 @@ async function main() {
     const skaleTokenAddress = await skaleToken.getAddress();
     console.log(`${skaleTokenName} deployed at:`, skaleTokenAddress);
 
+    try {
+        console.log(`Registering ${skaleTokenName} in ContractManager`);
+        await (await contractManager.setContractsAddress(skaleTokenName, skaleToken)).wait();
+    } catch (error) {
+        console.log(chalk.yellow("Warning: SkaleToken was not registered in ContractManager."));
+        console.log(chalk.yellow("Ensure that setContractsAddress in ContractManager is executed via the multisig."));
+    }
+
     console.log(`Granting MINTER_ROLE for L2 bridge: ${l2BridgeAddress}`);
     const MINTER_ROLE = await skaleToken.MINTER_ROLE();
     await (await skaleToken.grantRole(MINTER_ROLE, l2BridgeAddress)).wait();
@@ -84,8 +92,6 @@ async function main() {
 
     console.log("Verify contract");
     await verify(skaleTokenName, skaleTokenAddress, [contractManagerAddress, [], remoteTokenAddress, l2BridgeAddress]);
-
-    chalk.yellow("Warning: Ensure that setContractsAddress in ContractManager is executed via the multisig.");
 
     console.log("Done");
 }

--- a/migrations/deploySkaleTokenL2.ts
+++ b/migrations/deploySkaleTokenL2.ts
@@ -78,7 +78,7 @@ async function main() {
     try {
         console.log(`Registering ${skaleTokenName} in ContractManager`);
         await (await contractManager.setContractsAddress(skaleTokenName, skaleToken)).wait();
-    } catch (error) {
+    } catch {
         console.log(chalk.yellow("Warning: SkaleToken was not registered in ContractManager."));
         console.log(chalk.yellow("Ensure that setContractsAddress in ContractManager is executed via the multisig."));
     }


### PR DESCRIPTION
`PRIVATE_KEY` used for deployment does not have permission to register SkaleToken in ContractManager. It is better to remove the corresponding line and perform the registration manually.
closes #1190 