### PR TITLE
Fix minting of L2 token

### DIFF
--- a/contracts/l2/SkaleTokenL2.sol
+++ b/contracts/l2/SkaleTokenL2.sol
@@ -49,6 +49,7 @@ contract SkaleTokenL2 is SkaleToken, IOptimismMintableERC20, IERC777Recipient {
     address public immutable bridge;
 
     error ZeroAddress(string param);
+    error MintingFailed();
 
     constructor(
         address _contractManager,
@@ -78,7 +79,9 @@ contract SkaleTokenL2 is SkaleToken, IOptimismMintableERC20, IERC777Recipient {
     function mint(address account, uint256 amount) external override onlyMinter {
         require(amount <= CAP - totalSupply(), "Amount is too big");
         _mint(address(this), amount, "", "");
-        this.transfer(account, amount);
+        if(!this.transfer(account, amount)) {
+            revert MintingFailed();
+        }
     }
 
     /**

--- a/contracts/l2/SkaleTokenL2.sol
+++ b/contracts/l2/SkaleTokenL2.sol
@@ -27,13 +27,14 @@ import {
     IERC165,
     IOptimismMintableERC20
 } from "@eth-optimism/contracts-bedrock/src/universal/IOptimismMintableERC20.sol";
+import "@openzeppelin/contracts/token/ERC777/IERC777Recipient.sol";
 import { SkaleToken } from "../SkaleToken.sol";
 
 /**
  * @title SkaleTokenL2
  * @dev Contract defines the SKALE token for L1-L2 interaction.
  */
-contract SkaleTokenL2 is SkaleToken, IOptimismMintableERC20 {
+contract SkaleTokenL2 is SkaleToken, IOptimismMintableERC20, IERC777Recipient {
 
     /**
      * @dev Address of the L1 SKALE token contract.
@@ -63,6 +64,8 @@ contract SkaleTokenL2 is SkaleToken, IOptimismMintableERC20 {
             revert ZeroAddress("bridge");
         remoteToken = _remoteToken;
         bridge = _bridge;
+
+        _ERC1820_REGISTRY.setInterfaceImplementer(address(this), keccak256("ERC777TokensRecipient"), address(this));
     }
 
     /**
@@ -70,7 +73,8 @@ contract SkaleTokenL2 is SkaleToken, IOptimismMintableERC20 {
      */
     function mint(address account, uint256 amount) external override onlyMinter {
         require(amount <= CAP - totalSupply(), "Amount is too big");
-        _mint(account, amount, "", "");
+        _mint(address(this), amount, "", "");
+        this.transfer(account, amount);
     }
 
     /**
@@ -87,6 +91,20 @@ contract SkaleTokenL2 is SkaleToken, IOptimismMintableERC20 {
      function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
         bytes4 interfaceERC165 = type(IERC165).interfaceId;
         bytes4 interfaceOptimismMintableERC20 = type(IOptimismMintableERC20).interfaceId;
-        return interfaceId == interfaceERC165 || interfaceId == interfaceOptimismMintableERC20;
+        bytes4 interfaceERC777Recipient = type(IERC777Recipient).interfaceId;
+        return interfaceId == interfaceERC165
+            || interfaceId == interfaceOptimismMintableERC20
+            || interfaceId == interfaceERC777Recipient;
     }
+
+    /// @dev IERC777Recipient implementation
+    /// @dev Required to allow minting to itself
+    function tokensReceived(
+        address /* operator */,
+        address /* from */,
+        address /* to */,
+        uint256 /* amount */,
+        bytes calldata /* userData */,
+        bytes calldata /* operatorData */
+    ) external pure override {}
 }

--- a/contracts/l2/SkaleTokenL2.sol
+++ b/contracts/l2/SkaleTokenL2.sol
@@ -27,7 +27,7 @@ import {
     IERC165,
     IOptimismMintableERC20
 } from "@eth-optimism/contracts-bedrock/src/universal/IOptimismMintableERC20.sol";
-import "@openzeppelin/contracts/token/ERC777/IERC777Recipient.sol";
+import { IERC777Recipient } from "@openzeppelin/contracts/token/ERC777/IERC777Recipient.sol";
 import { SkaleToken } from "../SkaleToken.sol";
 
 /**
@@ -65,7 +65,11 @@ contract SkaleTokenL2 is SkaleToken, IOptimismMintableERC20, IERC777Recipient {
         remoteToken = _remoteToken;
         bridge = _bridge;
 
-        _ERC1820_REGISTRY.setInterfaceImplementer(address(this), keccak256("ERC777TokensRecipient"), address(this));
+        _ERC1820_REGISTRY.setInterfaceImplementer(
+            address(this),
+            keccak256("ERC777TokensRecipient"),
+            address(this)
+        );
     }
 
     /**
@@ -106,5 +110,9 @@ contract SkaleTokenL2 is SkaleToken, IOptimismMintableERC20, IERC777Recipient {
         uint256 /* amount */,
         bytes calldata /* userData */,
         bytes calldata /* operatorData */
-    ) external pure override {}
+    ) external pure override
+    // The callback has to be implemented to allow minting to itself
+    // but there is no need to do anything in it
+    // solhint-disable-next-line no-empty-blocks
+    {}
 }

--- a/test/l2/SkaleTokenL2.ts
+++ b/test/l2/SkaleTokenL2.ts
@@ -1,0 +1,47 @@
+import {ContractManager,
+    SkaleTokenL2,
+} from "../../typechain-types";
+
+import * as chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import {deployContractManager} from "../tools/deploy/contractManager";
+import {deploySkaleManagerMock} from "../tools/deploy/test/skaleManagerMock";
+import {ethers} from "hardhat";
+import {SignerWithAddress} from "@nomicfoundation/hardhat-ethers/signers";
+import {fastBeforeEach} from "../tools/mocha";
+import { deployTokenState } from "../tools/deploy/delegation/tokenState";
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe("SkaleTokenL2", () => {
+    let owner: SignerWithAddress;
+    let remoteToken: SignerWithAddress;
+    let bridge: SignerWithAddress;
+
+    let skaleTokenL2: SkaleTokenL2;
+    let contractManager: ContractManager;
+
+    fastBeforeEach(async () => {
+        [owner, remoteToken, bridge] = await ethers.getSigners();
+
+        contractManager = await deployContractManager();
+        await deployTokenState(contractManager);
+
+        skaleTokenL2 = await ethers.deployContract(
+            "SkaleTokenL2",
+            [contractManager, [], remoteToken, bridge]
+        ) as unknown as SkaleTokenL2;
+
+        await skaleTokenL2.grantRole(await skaleTokenL2.MINTER_ROLE(), owner);
+
+        const premined = ethers.parseEther("5000000000"); // 5e9 * 1e18
+        await skaleTokenL2["mint(address,uint256)"](owner, premined);
+    });
+
+    it("should allow minting tokens to ERC777 incompatible contracts", async () => {
+        const value = ethers.parseEther("1");
+        await skaleTokenL2["mint(address,uint256)"](contractManager, value);
+        await skaleTokenL2.balanceOf(contractManager).should.eventually.equal(value);
+    });
+});

--- a/test/l2/SkaleTokenL2.ts
+++ b/test/l2/SkaleTokenL2.ts
@@ -5,11 +5,10 @@ import {ContractManager,
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import {deployContractManager} from "../tools/deploy/contractManager";
-import {deploySkaleManagerMock} from "../tools/deploy/test/skaleManagerMock";
 import {ethers} from "hardhat";
 import {SignerWithAddress} from "@nomicfoundation/hardhat-ethers/signers";
 import {fastBeforeEach} from "../tools/mocha";
-import { deployTokenState } from "../tools/deploy/delegation/tokenState";
+import {deployTokenState} from "../tools/deploy/delegation/tokenState";
 
 chai.should();
 chai.use(chaiAsPromised);


### PR DESCRIPTION
Change `mint` function to first mint to itself and then send to the receiver
to not require receiver to implemenet `ERC777Recipient` interface.

Supporting changes:
- implement the `IERC777Recipient` interface
- register `tokensReceived` callback in the ERC1820 registry
- update `supportsInterface`
- add unit test to reproduce the issue